### PR TITLE
FI-3156 Loosen checks on scopes received with successful registration response

### DIFF
--- a/lib/udap_security_test_kit/registration_success_contents_test.rb
+++ b/lib/udap_security_test_kit/registration_success_contents_test.rb
@@ -48,7 +48,14 @@ module UDAPSecurityTestKit
 
       original_software_statement = JSON.parse(udap_software_statement_json)
 
-      expected_claims = ['client_name', 'grant_types', 'token_endpoint_auth_method', 'scope']
+      # Scopes received will not exactly match scopes requested if wildcard used
+      # for request (e.g., patient/*.read)
+      # Keep it simple here and just check that scopes are returned, save more
+      # detailed assessment of scope values for SMART-UDAP test kit?
+      assert registration_response.key?('scope'), "Successful registration response must include 'scope' claim"
+      assert registration_response['scope'].present?, 'Scope cannot be blank'
+
+      expected_claims = ['client_name', 'grant_types', 'token_endpoint_auth_method']
       auth_code_claims = ['redirect_uris', 'response_types']
 
       expected_claims.concat auth_code_claims if udap_registration_grant_type == 'authorization_code'

--- a/lib/udap_security_test_kit/registration_success_contents_test.rb
+++ b/lib/udap_security_test_kit/registration_success_contents_test.rb
@@ -48,10 +48,7 @@ module UDAPSecurityTestKit
 
       original_software_statement = JSON.parse(udap_software_statement_json)
 
-      # Scopes received will not exactly match scopes requested if wildcard used
-      # for request (e.g., patient/*.read)
-      # Keep it simple here and just check that scopes are returned, save more
-      # detailed assessment of scope values for SMART-UDAP test kit?
+      # Scopes received may not exactly match scopes requested
       assert registration_response.key?('scope'), "Successful registration response must include 'scope' claim"
       assert registration_response['scope'].present?, 'Scope cannot be blank'
 

--- a/spec/udap_security_test_kit/registration_success_contents_test_spec.rb
+++ b/spec/udap_security_test_kit/registration_success_contents_test_spec.rb
@@ -35,10 +35,17 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
       "scope": "user/*.read"}'
   end
 
-  let(:expected_claims) do
-    ['client_name',
-     'grant_types',
+  let(:required_immutable_claims) do
+    ['grant_types',
      'token_endpoint_auth_method']
+  end
+
+  let(:required_mutable_claims) do
+    ['scope', 'client_name']
+  end
+
+  let(:all_required_claims) do
+    (required_immutable_claims + required_mutable_claims).append('client_id')
   end
 
   def run(runnable, inputs = {})
@@ -55,47 +62,8 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  it 'fails if response does not include client_id parameter' do
-    response = '{
-      "software_statement": "example_jwt",
-      "client_name": "Inferno UDAP Authorization Code Test Client",
-      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
-      "grant_types": ["authorization_code"],
-      "response_types": ["code"],
-      "token_endpoint_auth_method": "private_key_jwt"
-    }'
-    result = run(runnable,
-                 udap_software_statement_json:,
-                 udap_software_statement_jwt:,
-                 udap_registration_response: response,
-                 udap_registration_grant_type:)
-
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/client_id/)
-  end
-
-  it 'fails if client_id parameter in registration response is blank' do
-    response = '{
-      "client_id": "",
-      "software_statement": "example_jwt",
-      "client_name": "Inferno UDAP Authorization Code Test Client",
-      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
-      "grant_types": ["authorization_code"],
-      "response_types": ["code"],
-      "token_endpoint_auth_method": "private_key_jwt"
-    }'
-    result = run(runnable,
-                 udap_software_statement_json:,
-                 udap_software_statement_jwt:,
-                 udap_registration_response: response,
-                 udap_registration_grant_type:)
-
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/client_id/)
-  end
-
-  it 'fails if response does not include relevant claims from original request' do
-    expected_claims.each do |key|
+  it 'fails if response does not include required claims' do
+    all_required_claims.each do |key|
       response_json = JSON.parse(correct_response)
       response_json.delete(key)
       result = run(runnable,
@@ -108,10 +76,10 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
     end
   end
 
-  it 'fails if response values do not match values submitted in original request' do
-    expected_claims.each do |key|
+  it 'fails if response values for required claims are blank' do
+    all_required_claims.each do |key|
       response_json = JSON.parse(correct_response)
-      response_json[key] = 'incorrect_value'
+      response_json[key] = ''
       result = run(runnable,
                    udap_software_statement_json:,
                    udap_software_statement_jwt:,
@@ -122,48 +90,34 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
     end
   end
 
-  it 'fails if response does not include scope parameter' do
-    response = '{
-      "client_id": "example_client_id",
-      "software_statement": "example_jwt",
-      "client_name": "Inferno UDAP Authorization Code Test Client",
-      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
-      "grant_types": ["authorization_code"],
-      "response_types": ["code"],
-      "token_endpoint_auth_method": "private_key_jwt"
-    }'
-    result = run(runnable,
-                 udap_software_statement_json:,
-                 udap_software_statement_jwt:,
-                 udap_registration_response: response,
-                 udap_registration_grant_type:)
-
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/must include 'scope'/)
+  it 'fails if response values for immutable claims do not match values submitted in original request' do
+    required_immutable_claims.each do |key|
+      response_json = JSON.parse(correct_response)
+      response_json[key] = 'CHANGED_VALUE'
+      result = run(runnable,
+                   udap_software_statement_json:,
+                   udap_software_statement_jwt:,
+                   udap_registration_response: JSON.generate(response_json),
+                   udap_registration_grant_type:)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(key.to_s)
+    end
   end
 
-  it 'fails if scope parameter in registration response is blank' do
-    response = '{
-      "client_id": "example_client_id",
-      "software_statement": "example_jwt",
-      "client_name": "Inferno UDAP Authorization Code Test Client",
-      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
-      "grant_types": ["authorization_code"],
-      "response_types": ["code"],
-      "token_endpoint_auth_method": "private_key_jwt",
-      "scope": ""
-    }'
-    result = run(runnable,
-                 udap_software_statement_json:,
-                 udap_software_statement_jwt:,
-                 udap_registration_response: response,
-                 udap_registration_grant_type:)
-
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/Scope cannot be blank/)
+  it 'passes if mutable claim values in registration response differ from original client request values' do
+    required_mutable_claims.each do |key|
+      response_json = JSON.parse(correct_response)
+      response_json[key] = 'CHANGED VALUE'
+      result = run(runnable,
+                   udap_software_statement_json:,
+                   udap_software_statement_jwt:,
+                   udap_registration_response: JSON.generate(response_json),
+                   udap_registration_grant_type:)
+      expect(result.result).to eq('pass')
+    end
   end
 
-  it 'passes when response contains all required values' do
+  it 'passes when all required values in registration response exactly match original client request values' do
     result = run(runnable,
                  udap_software_statement_json:,
                  udap_software_statement_jwt:,

--- a/spec/udap_security_test_kit/registration_success_contents_test_spec.rb
+++ b/spec/udap_security_test_kit/registration_success_contents_test_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
   let(:expected_claims) do
     ['client_name',
      'grant_types',
-     'token_endpoint_auth_method',
-     'scope']
+     'token_endpoint_auth_method']
   end
 
   def run(runnable, inputs = {})
@@ -121,6 +120,47 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessContentsTest do
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(key.to_s)
     end
+  end
+
+  it 'fails if response does not include scope parameter' do
+    response = '{
+      "client_id": "example_client_id",
+      "software_statement": "example_jwt",
+      "client_name": "Inferno UDAP Authorization Code Test Client",
+      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
+      "grant_types": ["authorization_code"],
+      "response_types": ["code"],
+      "token_endpoint_auth_method": "private_key_jwt"
+    }'
+    result = run(runnable,
+                 udap_software_statement_json:,
+                 udap_software_statement_jwt:,
+                 udap_registration_response: response,
+                 udap_registration_grant_type:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/must include 'scope'/)
+  end
+
+  it 'fails if scope parameter in registration response is blank' do
+    response = '{
+      "client_id": "example_client_id",
+      "software_statement": "example_jwt",
+      "client_name": "Inferno UDAP Authorization Code Test Client",
+      "redirect_uris": ["https:/localhost/suites/custom/udap_security_test_kit/redirect"],
+      "grant_types": ["authorization_code"],
+      "response_types": ["code"],
+      "token_endpoint_auth_method": "private_key_jwt",
+      "scope": ""
+    }'
+    result = run(runnable,
+                 udap_software_statement_json:,
+                 udap_software_statement_jwt:,
+                 udap_registration_response: response,
+                 udap_registration_grant_type:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/Scope cannot be blank/)
   end
 
   it 'passes when response contains all required values' do


### PR DESCRIPTION
# Summary
This PR fixes a bug in which the successful registration test has overly strict and inaccurate requirements for the scope parameter returned by the authorization server after a successful client registration request.

The HL7 UDAP IG refers to [Section 5.1 of the udap.org profile on Dynamic Client Registration](https://www.udap.org/udap-dynamic-client-registration-stu1.html#section-5.1), which says the following about what the auth server must include in its response to a successful registration request:
> The top-level elements of the response SHALL include the client_id issued by the Authorization Server for use by the Client App, the software statement as submitted by the Client App, and *all of the registration related parameters that were included in the software statement.*

Currently, the tests interpret this to mean that the values between the request (software statement) and auth server response should match exactly. However, this does not apply for scopes, where the use of wildcards can expand the initial requested scope into one or more specific FHIR resources granted, e.g., `patient/*.read` could resolve to `patient/AllergyIntolerance.read`, `patient/Condition.read`, etc. The current implementation also does not account for cases where only a subset of the requested scopes may be granted.

To account for this, the test has been updated to no longer expect an exact string match between requested and received scopes. Instead, it verifies that the `scope` parameter is present and that its value is not blank.
More detailed analysis of scopes is conducted in the SMART-UDAP Harmonization test kit.

# Testing Guidance
Unit tests have been updated and all are passing. 
