### PR TITLE
FI-3219 Add access token outputs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rouge (4.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/lib/udap_security_test_kit/authorization_code_authentication_group.rb
+++ b/lib/udap_security_test_kit/authorization_code_authentication_group.rb
@@ -30,6 +30,17 @@ module UDAPSecurityTestKit
              token_response_body: {
                name: :authorization_code_token_response_body
              }
+           },
+           outputs: {
+             udap_access_token: {
+               name: :udap_auth_code_flow_access_token
+             },
+             udap_expires_in: {
+               name: :udap_auth_code_flow_expires_in
+             },
+             udap_received_scopes: {
+               name: :udap_auth_code_flow_received_scopes
+             }
            }
          }
     test from: :udap_token_exchange_response_headers,

--- a/lib/udap_security_test_kit/authorization_code_authentication_group.rb
+++ b/lib/udap_security_test_kit/authorization_code_authentication_group.rb
@@ -40,6 +40,9 @@ module UDAPSecurityTestKit
              },
              udap_received_scopes: {
                name: :udap_auth_code_flow_received_scopes
+             },
+             udap_refresh_token: {
+               name: :udap_auth_code_flow_refresh_token
              }
            }
          }

--- a/lib/udap_security_test_kit/authorization_code_authentication_group.rb
+++ b/lib/udap_security_test_kit/authorization_code_authentication_group.rb
@@ -20,7 +20,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :authorization_code_token_exchange
+               name: :udap_auth_code_flow_token_exchange
              }
            }
          }
@@ -28,7 +28,7 @@ module UDAPSecurityTestKit
          config: {
            inputs: {
              token_response_body: {
-               name: :authorization_code_token_response_body
+               name: :udap_auth_code_flow_token_exchange_response_body
              }
            },
            outputs: {
@@ -47,7 +47,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :authorization_code_token_exchange
+               name: :udap_auth_code_flow_token_exchange
              }
            }
          }

--- a/lib/udap_security_test_kit/authorization_code_token_exchange_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_token_exchange_test.rb
@@ -57,8 +57,9 @@ module UDAPSecurityTestKit
           default: 'RS256',
           locked: true
 
-    output :token_retrieval_time
-    output :authorization_code_token_response_body
+    output :udap_auth_code_flow_token_retrieval_time,
+           :udap_auth_code_flow_token_exchange_response_body
+
     makes_request :token_exchange
 
     config options: { redirect_uri: "#{Inferno::Application['base_url']}/custom/udap_security_test_kit/redirect" }
@@ -95,9 +96,9 @@ module UDAPSecurityTestKit
       assert_response_status(200)
       assert_valid_json(request.response_body)
 
-      output token_retrieval_time: Time.now.iso8601
+      output udap_auth_code_flow_token_retrieval_time: Time.now.iso8601
 
-      output authorization_code_token_response_body: request.response_body
+      output udap_auth_code_flow_token_exchange_response_body: request.response_body
     end
   end
 end

--- a/lib/udap_security_test_kit/client_credentials_authentication_group.rb
+++ b/lib/udap_security_test_kit/client_credentials_authentication_group.rb
@@ -16,7 +16,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :udap_client_creds_flow_token_exchange
+               name: :udap_client_credentials_flow_token_exchange
              }
            }
          }
@@ -24,18 +24,18 @@ module UDAPSecurityTestKit
          config: {
            inputs: {
              token_response_body: {
-               name: :udap_client_creds_flow_token_exchange_response_body
+               name: :udap_client_credentials_flow_token_exchange_response_body
              }
            },
            outputs: {
              udap_access_token: {
-               name: :udap_client_creds_flow_access_token
+               name: :udap_client_credentials_flow_access_token
              },
              udap_expires_in: {
-               name: :udap_client_creds_flow_expires_in
+               name: :udap_client_credentials_flow_expires_in
              },
              udap_received_scopes: {
-               name: :udap_client_creds_flow_received_scopes
+               name: :udap_client_credentials_flow_received_scopes
              }
            }
          }
@@ -43,7 +43,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :udap_client_creds_flow_token_exchange
+               name: :udap_client_credentials_flow_token_exchange
              }
            }
          }

--- a/lib/udap_security_test_kit/client_credentials_authentication_group.rb
+++ b/lib/udap_security_test_kit/client_credentials_authentication_group.rb
@@ -16,7 +16,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :client_credentials_token_exchange
+               name: :udap_client_creds_flow_token_exchange
              }
            }
          }
@@ -24,7 +24,7 @@ module UDAPSecurityTestKit
          config: {
            inputs: {
              token_response_body: {
-               name: :client_credentials_token_response_body
+               name: :udap_client_creds_flow_token_exchange_response_body
              }
            },
            outputs: {
@@ -43,7 +43,7 @@ module UDAPSecurityTestKit
          config: {
            requests: {
              token_exchange: {
-               name: :client_credentials_token_exchange
+               name: :udap_client_creds_flow_token_exchange
              }
            }
          }

--- a/lib/udap_security_test_kit/client_credentials_authentication_group.rb
+++ b/lib/udap_security_test_kit/client_credentials_authentication_group.rb
@@ -26,6 +26,17 @@ module UDAPSecurityTestKit
              token_response_body: {
                name: :client_credentials_token_response_body
              }
+           },
+           outputs: {
+             udap_access_token: {
+               name: :udap_client_creds_flow_access_token
+             },
+             udap_expires_in: {
+               name: :udap_client_creds_flow_expires_in
+             },
+             udap_received_scopes: {
+               name: :udap_client_creds_flow_received_scopes
+             }
            }
          }
     test from: :udap_token_exchange_response_headers,

--- a/lib/udap_security_test_kit/client_credentials_authentication_group.rb
+++ b/lib/udap_security_test_kit/client_credentials_authentication_group.rb
@@ -36,6 +36,9 @@ module UDAPSecurityTestKit
              },
              udap_received_scopes: {
                name: :udap_client_credentials_flow_received_scopes
+             },
+             udap_refresh_token: {
+               name: :udap_client_credentials_flow_refresh_token
              }
            }
          }

--- a/lib/udap_security_test_kit/client_credentials_token_exchange_test.rb
+++ b/lib/udap_security_test_kit/client_credentials_token_exchange_test.rb
@@ -71,8 +71,8 @@ module UDAPSecurityTestKit
           default: 'RS256',
           locked: true
 
-    output :udap_client_creds_flow_token_retrieval_time,
-           :udap_client_creds_flow_token_exchange_response_body
+    output :udap_client_credentials_flow_token_retrieval_time,
+           :udap_client_credentials_flow_token_exchange_response_body
 
     makes_request :token_exchange
 
@@ -123,9 +123,9 @@ module UDAPSecurityTestKit
       assert_response_status(200)
       assert_valid_json(request.response_body)
 
-      output udap_client_creds_flow_token_retrieval_time: Time.now.iso8601
+      output udap_client_credentials_flow_token_retrieval_time: Time.now.iso8601
 
-      output udap_client_creds_flow_token_exchange_response_body: request.response_body
+      output udap_client_credentials_flow_token_exchange_response_body: request.response_body
     end
   end
 end

--- a/lib/udap_security_test_kit/client_credentials_token_exchange_test.rb
+++ b/lib/udap_security_test_kit/client_credentials_token_exchange_test.rb
@@ -71,8 +71,9 @@ module UDAPSecurityTestKit
           default: 'RS256',
           locked: true
 
-    output :token_retrieval_time
-    output :client_credentials_token_response_body
+    output :udap_client_creds_flow_token_retrieval_time,
+           :udap_client_creds_flow_token_exchange_response_body
+
     makes_request :token_exchange
 
     run do
@@ -122,9 +123,9 @@ module UDAPSecurityTestKit
       assert_response_status(200)
       assert_valid_json(request.response_body)
 
-      output token_retrieval_time: Time.now.iso8601
+      output udap_client_creds_flow_token_retrieval_time: Time.now.iso8601
 
-      output client_credentials_token_response_body: request.response_body
+      output udap_client_creds_flow_token_exchange_response_body: request.response_body
     end
   end
 end

--- a/lib/udap_security_test_kit/token_exchange_response_body_test.rb
+++ b/lib/udap_security_test_kit/token_exchange_response_body_test.rb
@@ -15,9 +15,17 @@ module UDAPSecurityTestKit
 
     input :token_response_body
 
+    output :udap_access_token,
+           :udap_expires_in,
+           :udap_received_scopes
+
     run do
       assert_valid_json(token_response_body)
       token_response_body_parsed = JSON.parse(token_response_body)
+
+      output udap_access_token: token_response_body_parsed['access_token'],
+             udap_expires_in: token_response_body_parsed['expires_in'],
+             udap_received_scopes: token_response_body_parsed['scope']
 
       required_keys = ['access_token', 'token_type']
 

--- a/lib/udap_security_test_kit/token_exchange_response_body_test.rb
+++ b/lib/udap_security_test_kit/token_exchange_response_body_test.rb
@@ -17,7 +17,8 @@ module UDAPSecurityTestKit
 
     output :udap_access_token,
            :udap_expires_in,
-           :udap_received_scopes
+           :udap_received_scopes,
+           :udap_refresh_token
 
     run do
       assert_valid_json(token_response_body)
@@ -25,7 +26,8 @@ module UDAPSecurityTestKit
 
       output udap_access_token: token_response_body_parsed['access_token'],
              udap_expires_in: token_response_body_parsed['expires_in'],
-             udap_received_scopes: token_response_body_parsed['scope']
+             udap_received_scopes: token_response_body_parsed['scope'],
+             udap_refresh_token: token_response_body_parsed['refresh_token']
 
       required_keys = ['access_token', 'token_type']
 


### PR DESCRIPTION
# Summary
Currently, the UDAP token exchange tests have an output for the entire JSON response body from the token exchange, and tests interested in using any of the values from the response must re-parse the entire response body.

This PR updates tests to use specific outputs for access token, received scopes, and expiration time for easier use by downstream tests. I also did some minor changes to the existing input names to be fully consistent with the input refactor done in a previous PR.

# Testing Guidance
None - unit tests are not impacted, and we do not have a reference implementation to test against that would visualize the outputs in the web app.
