### PR TITLE
Draft: FI-3113 Improve testing scope description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # Inferno UDAP Security IG Test Kit 
 
-This is a collection of tests for the [UDAP Security
-IG](https://hl7.org/fhir/us/udap-security/index.html).
+This is a collection of tests to verify server conformance to the [HL7 UDAP Security
+STU 1.0 IG](https://hl7.org/fhir/us/udap-security/STU1/index.html). 
+Specifically, this test
+kit assesses the required capabilities from the following sections:
+- [JSON Web Token (JWT) Requirements](https://hl7.org/fhir/us/udap-security/STU1/index.html)
+- [Discovery](https://hl7.org/fhir/us/udap-security/STU1/index.html)
+- [Dynamic Client Registration](https://hl7.org/fhir/us/udap-security/STU1/registration.html)
+- [Consumer-Facing Authorization & Authentication](https://hl7.org/fhir/us/udap-security/STU1/registration.html)
+- [Business-to-Business (B2B) Authorization & Authentication](https://hl7.org/fhir/us/udap-security/STU1/b2b.html)
+
+[Tiered OAuth for User
+Authentication](https://hl7.org/fhir/us/udap-security/STU1/user.html) is not a
+required capability and is not assessed. 
+This test kit also does not assess client conformance.
 
 ## Instructions
 

--- a/lib/udap_security_test_kit.rb
+++ b/lib/udap_security_test_kit.rb
@@ -17,7 +17,8 @@ module UDAPSecurityTestKit
       2. Dynamic Client Registration
       3. Authorization & Authentication
 
-      These steps are grouped by the OAuth2.0 flow being tested:
+      In this test suite, Inferno acts as a mock UDAP client to test *server conformance* to the HL7 UDAP IG. Tests are
+      grouped according to the OAuth2.0 flow used in the authorization and authentication step:
       1. Authorization Code flow, which supports
         [Consumer-Facing](https://hl7.org/fhir/us/udap-security/STU1/consumer.html) or [Business-to-Business (B2B)](https://hl7.org/fhir/us/udap-security/STU1/b2b.html)
         use cases
@@ -25,6 +26,9 @@ module UDAPSecurityTestKit
       [B2B](https://hl7.org/fhir/us/udap-security/STU1/b2b.html) use case
 
       Testers may test one or both flows based on their system under test.
+
+      This test suite does NOT assess [Tiered OAuth for User Authentication](https://hl7.org/fhir/us/udap-security/STU1/user.html)
+      (which is not a required capability) or client conformance to the HL7 UDAP IG.
     )
 
     input_instructions %(


### PR DESCRIPTION
# Summary
This PR updates the README and test suite description to better clarify the scope of testing, including which sections of the IG are tested and clarifying that it only does server testing, not client testing.

TODO: update the inferno.healthit.gov test description.
