### PR TITLE
FI-3220 Add scope and aud parameters as optional inputs for authorization code redirect test

### DIFF
--- a/lib/udap_security_test_kit/authorization_code_redirect_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_redirect_test.rb
@@ -35,6 +35,7 @@ module UDAPSecurityTestKit
           optional: true
 
     output :udap_authorization_code_state
+    output :udap_authorization_redirect_url
 
     receives_request :redirect
 
@@ -77,7 +78,7 @@ module UDAPSecurityTestKit
         'client_id' => udap_client_id,
         'redirect_uri' => config.options[:redirect_uri],
         'state' => udap_authorization_code_state,
-        'scope' => udap_authorization_request_requested_scopes,
+        'scope' => udap_authorization_code_request_scopes,
         'aud' => udap_authorization_code_request_aud
       }.compact
 
@@ -87,6 +88,8 @@ module UDAPSecurityTestKit
       )
 
       info("Inferno redirecting browser to #{authorization_url}.")
+
+      output udap_authorization_redirect_url: authorization_url
 
       wait(
         identifier: udap_authorization_code_state,

--- a/lib/udap_security_test_kit/authorization_code_redirect_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_redirect_test.rb
@@ -37,7 +37,7 @@ module UDAPSecurityTestKit
             list_options: [
               {
                 label: "Include 'aud' parameter",
-                value: 'include'
+                value: 'include_aud'
               }
             ]
           },
@@ -86,13 +86,15 @@ module UDAPSecurityTestKit
 
       output udap_authorization_code_state: SecureRandom.uuid
 
+      aud = udap_fhir_base_url if udap_authorization_code_request_aud.include? 'include_aud'
+
       oauth2_params = {
         'response_type' => 'code',
         'client_id' => udap_client_id,
         'redirect_uri' => config.options[:redirect_uri],
         'state' => udap_authorization_code_state,
         'scope' => udap_authorization_code_request_scopes,
-        'aud' => udap_authorization_code_request_aud
+        'aud' => aud
       }.compact
 
       authorization_url = authorization_url_builder(

--- a/lib/udap_security_test_kit/authorization_code_redirect_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_redirect_test.rb
@@ -9,6 +9,10 @@ module UDAPSecurityTestKit
         the provided client redirection URI using an HTTP redirection response.
       )
 
+    input :udap_fhir_base_url,
+          title: 'FHIR Server Base URL',
+          description: 'Base FHIR URL of FHIR Server.'
+
     input :udap_authorization_endpoint,
           title: 'Authorization Endpoint',
           description: 'The full URL from which Inferno will request an authorization code.'
@@ -28,9 +32,18 @@ module UDAPSecurityTestKit
 
     input :udap_authorization_code_request_aud,
           title: "Audience ('aud') Parameter for Authorization Request",
+          type: 'checkbox',
+          options: {
+            list_options: [
+              {
+                label: "Include 'aud' parameter",
+                value: 'include'
+              }
+            ]
+          },
           description: %(
-              If included, should be the same as the base FHIR URL. If empty, 'aud' parameter will be omitted as
-              a parameter to the authorization endpoint.
+              If selected, the Base FHIR URL will be used as the 'aud' parameter in the request to the authorization
+              endpoint.
           ),
           optional: true
 

--- a/lib/udap_security_test_kit/authorization_code_redirect_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_redirect_test.rb
@@ -17,6 +17,23 @@ module UDAPSecurityTestKit
           title: 'Client ID',
           description: 'Client ID as registered with the authorization server.'
 
+    input :udap_authorization_code_request_scopes,
+          title: 'Scope Parameter for Authorization Request',
+          description: %(
+              A list of space-separated scopes to include in the authorization request. If included, these may be equal
+              to or a subset of the scopes requested during registration.
+              If empty, scope will be omitted as a parameter to the authorization endpoint.
+          ),
+          optional: true
+
+    input :udap_authorization_code_request_aud,
+          title: "Audience ('aud') Parameter for Authorization Request",
+          description: %(
+              If included, should be the same as the base FHIR URL. If empty, 'aud' parameter will be omitted as
+              a parameter to the authorization endpoint.
+          ),
+          optional: true
+
     output :udap_authorization_code_state
 
     receives_request :redirect
@@ -59,7 +76,9 @@ module UDAPSecurityTestKit
         'response_type' => 'code',
         'client_id' => udap_client_id,
         'redirect_uri' => config.options[:redirect_uri],
-        'state' => udap_authorization_code_state
+        'state' => udap_authorization_code_state,
+        'scope' => udap_authorization_request_requested_scopes,
+        'aud' => udap_authorization_code_request_aud
       }.compact
 
       authorization_url = authorization_url_builder(

--- a/spec/udap_security_test_kit/authorization_code_redirect_test_spec.rb
+++ b/spec/udap_security_test_kit/authorization_code_redirect_test_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe UDAPSecurityTestKit::AuthorizationCodeRedirectTest, :request do
   let(:url) { 'http://example.com/fhir' }
   let(:inputs) do
     {
+      udap_fhir_base_url: url,
       udap_authorization_endpoint: 'http://example.com/authorize',
       udap_client_id: 'CLIENT_ID'
     }
@@ -18,7 +19,7 @@ RSpec.describe UDAPSecurityTestKit::AuthorizationCodeRedirectTest, :request do
   let(:inputs_scope_aud) do
     {
       udap_authorization_code_request_scopes: 'patient/Condition.rs',
-      udap_authorization_code_request_aud: 'http://example.com'
+      udap_authorization_code_request_aud: ['include_aud']
     }
   end
 

--- a/spec/udap_security_test_kit/authorization_code_redirect_test_spec.rb
+++ b/spec/udap_security_test_kit/authorization_code_redirect_test_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe UDAPSecurityTestKit::AuthorizationCodeRedirectTest, :request do
     }
   end
 
+  let(:inputs_scope_aud) do
+    {
+      udap_authorization_code_request_scopes: 'patient/Condition.rs',
+      udap_authorization_code_request_aud: 'http://example.com'
+    }
+  end
+
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
@@ -31,54 +38,96 @@ RSpec.describe UDAPSecurityTestKit::AuthorizationCodeRedirectTest, :request do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  it 'waits and then passes when it receives a request with the correct state' do
-    allow(test).to receive(:parent).and_return(Inferno::TestGroup)
-    result = run(test, inputs)
-    expect(result.result).to eq('wait')
+  context "when optional 'scope' and 'aud' inputs are omitted" do
+    it 'waits and then passes when it receives a request with the correct state' do
+      allow(test).to receive(:parent).and_return(Inferno::TestGroup)
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
 
-    state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
-    get "/custom/udap_security/redirect?state=#{state}"
+      state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
+      get "/custom/udap_security/redirect?state=#{state}"
 
-    result = results_repo.find(result.id)
-    expect(result.result).to eq('pass')
+      result = results_repo.find(result.id)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'continues to wait when it receives a request with the incorrect state' do
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      state = SecureRandom.uuid
+      get "/custom/smart/redirect?state=#{state}"
+
+      result = results_repo.find(result.id)
+      expect(result.result).to eq('wait')
+    end
+
+    it 'fails if the authorization url is invalid' do
+      inputs[:udap_authorization_endpoint] = 'invalid'
+      result = run(test, inputs)
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/is not a valid URI/)
+    end
+
+    it "persists the incoming 'redirect' request" do
+      allow(test).to receive(:parent).and_return(Inferno::TestGroup)
+      run(test, inputs)
+      state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
+      url = "/custom/udap_security/redirect?state=#{state}"
+      get url
+
+      request = requests_repo.find_named_request(test_session.id, 'redirect')
+      expect(request.url).to end_with(url)
+    end
+
+    it "persists the 'udap_authorization_code_state' output" do
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      state = result.result_message.match(/a state of `(.*)`/)[1]
+      persisted_state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
+
+      expect(persisted_state).to eq(state)
+    end
+
+    it "omits 'scope' and 'aud' values from authorization redirect url" do
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      authorization_url = session_data_repo.load(
+        test_session_id: test_session.id,
+        name: 'udap_authorization_redirect_url'
+      )
+
+      expect(authorization_url).to_not include('scope')
+      expect(authorization_url).to_not include('aud')
+    end
   end
 
-  it 'continues to wait when it receives a request with the incorrect state' do
-    result = run(test, inputs)
-    expect(result.result).to eq('wait')
+  context "when optional 'scope' and 'aud' inputs are provided" do
+    it 'waits and then passes when it receives a request with the correct state' do
+      allow(test).to receive(:parent).and_return(Inferno::TestGroup)
+      result = run(test, inputs.merge(inputs_scope_aud))
+      expect(result.result).to eq('wait')
 
-    state = SecureRandom.uuid
-    get "/custom/smart/redirect?state=#{state}"
+      state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
+      get "/custom/udap_security/redirect?state=#{state}"
 
-    result = results_repo.find(result.id)
-    expect(result.result).to eq('wait')
-  end
+      result = results_repo.find(result.id)
+      expect(result.result).to eq('pass')
+    end
 
-  it 'fails if the authorization url is invalid' do
-    inputs[:udap_authorization_endpoint] = 'invalid'
-    result = run(test, inputs)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/is not a valid URI/)
-  end
+    it "includes 'scope' and 'aud' values in authorization redirect url" do
+      result = run(test, inputs.merge(inputs_scope_aud))
+      expect(result.result).to eq('wait')
 
-  it "persists the incoming 'redirect' request" do
-    allow(test).to receive(:parent).and_return(Inferno::TestGroup)
-    run(test, inputs)
-    state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
-    url = "/custom/udap_security/redirect?state=#{state}"
-    get url
+      authorization_url = session_data_repo.load(
+        test_session_id: test_session.id,
+        name: 'udap_authorization_redirect_url'
+      )
 
-    request = requests_repo.find_named_request(test_session.id, 'redirect')
-    expect(request.url).to end_with(url)
-  end
-
-  it "persists the 'udap_authorization_code_state' output" do
-    result = run(test, inputs)
-    expect(result.result).to eq('wait')
-
-    state = result.result_message.match(/a state of `(.*)`/)[1]
-    persisted_state = session_data_repo.load(test_session_id: test_session.id, name: 'udap_authorization_code_state')
-
-    expect(persisted_state).to eq(state)
+      expect(authorization_url).to include('scope')
+      expect(authorization_url).to include('aud')
+    end
   end
 end


### PR DESCRIPTION
# Summary
Currently, the authorization code redirect test has no means of providing a `scope` parameter to the authorization endpoint. However, [RFC 6749 Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1), as referenced in the [HL7 UDAP STU 1.0 IG](https://hl7.org/fhir/us/udap-security/STU1/consumer.html#obtaining-an-authorization-code), states that inclusion of a `scope` parameter is _optional_, and testers should therefore be able to provide it as an optional input.

This PR adds an optional `scope` input for the authorization code redirect test. It also adds an optional input for the `aud` parameter, which is not mentioned in the HL7 UDAP IG or RFC 6749 but is required for SMART App Launch. These changes are effectively doing the same thing as the [authorization redirect test created in the SMART-UDAP Harmonization Test Kit](https://github.com/inferno-framework/smart-udap-harmonization-test-kit/blob/main/lib/smart_udap_harmonization_test_kit/smart_udap_authorization_code_redirect_test.rb). 

 My justification for including the `aud` parameter here, despite it not being required by RFC 6749 or the HL7 UDAP IG, is that it would reduce duplicated code across test kits. If this PR is merged, then the SMART-UDAP test kit can just import this updated test from the baseline UDAP test kit instead of having its own redirect test. It would also make the redirect test more reusable in other UDAP test contexts where an implementation is likely to support both SMART and UDAP. 

If we really don't want to allow testers to add an `aud` parameter in this test kit, we can always configure that input to be locked at the group level. 

# Testing Guidance
Unit tests were updated to account for changes. We don't have a reference implementation to run against, but inputs can be seen in the web UI.
