### PR TITLE
FI-3175 Allow testers to specify new or updated client registration attempt

### DIFF
--- a/lib/udap_security_test_kit/authorization_code_group.rb
+++ b/lib/udap_security_test_kit/authorization_code_group.rb
@@ -49,6 +49,9 @@ module UDAPSecurityTestKit
                 default: 'authorization_code',
                 locked: true
               },
+              udap_client_registration_status: {
+                name: :udap_auth_code_flow_client_registration_status
+              },
               udap_client_cert_pem: {
                 name: :udap_auth_code_flow_client_cert_pem,
                 title: 'Authorization Code Client Certificate(s) (PEM Format)'
@@ -90,6 +93,7 @@ module UDAPSecurityTestKit
           } do
       input_order :udap_registration_endpoint,
                   :udap_auth_code_flow_registration_grant_type,
+                  :udap_auth_code_flow_client_registration_status,
                   :udap_auth_code_flow_client_cert_pem,
                   :udap_auth_code_flow_client_private_key,
                   :udap_auth_code_flow_cert_iss,

--- a/lib/udap_security_test_kit/client_credentials_group.rb
+++ b/lib/udap_security_test_kit/client_credentials_group.rb
@@ -51,6 +51,9 @@ module UDAPSecurityTestKit
                 default: 'client_credentials',
                 locked: true
               },
+              udap_client_registration_status: {
+                name: :udap_client_credentials_flow_client_registration_status
+              },
               udap_client_cert_pem: {
                 name: :udap_client_credentials_flow_client_cert_pem,
                 title: 'Client Credentials Client Certificate(s) (PEM Format)'
@@ -92,6 +95,7 @@ module UDAPSecurityTestKit
           } do
       input_order :udap_registration_endpoint,
                   :udap_client_credentials_flow_registration_grant_type,
+                  :udap_client_credentials_flow_client_registration_status,
                   :udap_client_credentials_flow_client_cert_pem,
                   :udap_client_credentials_flow_client_private_key,
                   :udap_cert_iss_client_creds_flow,

--- a/lib/udap_security_test_kit/dynamic_client_registration_group.rb
+++ b/lib/udap_security_test_kit/dynamic_client_registration_group.rb
@@ -21,9 +21,10 @@ module UDAPSecurityTestKit
       Cancelling a UDAP client's registration is not a required server capability and as such the Inferno client has no
       way of resetting state on the authorization server after a successful registration attempt.  If a given
       certificate and issuer URI identity combination has already been registered with the authorization server, testers
-      may select the "Update Registration" option under Client Registration Status. This option will expect a `200 OK`
-      return status that indicates a registration modification, instead of the
-      `201 Created` return status required for a new registration entry.
+      whose systems support registration modifications
+      may select the "Update Registration" option under Client Registration Status. This option will accept either a
+      `200 OK` or `201 Created` return status. Registration attempts for a new client may only return `201 Created`,
+      per the [IG](https://hl7.org/fhir/us/udap-security/STU1/registration.html#request-body).
     )
     end
 
@@ -69,7 +70,7 @@ module UDAPSecurityTestKit
                 value: 'new'
               },
               {
-                label: 'Update Registration (200 Response Code Expected)',
+                label: 'Update Registration (200 or 201 Response Code Expected)',
                 value: 'update'
               }
             ]

--- a/lib/udap_security_test_kit/dynamic_client_registration_group.rb
+++ b/lib/udap_security_test_kit/dynamic_client_registration_group.rb
@@ -19,13 +19,11 @@ module UDAPSecurityTestKit
       establish a trust chain.
 
       Cancelling a UDAP client's registration is not a required server capability and as such the Inferno client has no
-      way of resetting state on the authorization server after a successful registration attempt.  Testers wishing to
-      run the Dynamic Client Registration tests more than once must do one of the following:
-      - Remove the Inferno test client's registration out-of-band before re-running tests, to register the original
-      client URI anew
-      - Specifiy a different client URI as the issuer input (if the client cert has more than one Subject Alternative
-      Name (SAN) URI entry), to register a different logical client with the original certificate
-      - Provide a different client certificate and its associated URI to register a new logical client
+      way of resetting state on the authorization server after a successful registration attempt.  If a given
+      certificate and issuer URI identity combination has already been registered with the authorization server, testers
+      may select the "Update Registration" option under Client Registration Status. This option will expect a `200 OK`
+      return status that indicates a registration modification, instead of the
+      `201 Created` return status required for a new registration entry.
     )
     end
 

--- a/lib/udap_security_test_kit/dynamic_client_registration_group.rb
+++ b/lib/udap_security_test_kit/dynamic_client_registration_group.rb
@@ -57,6 +57,27 @@ module UDAPSecurityTestKit
             ]
           }
 
+    input :udap_client_registration_status,
+          title: 'Client Registration Status',
+          description: %(
+            If the client's iss and certificate combination has already been registered with the authorization server
+            prior to this test run, select 'Update'.
+          ),
+          type: 'radio',
+          options: {
+            list_options: [
+              {
+                label: 'New Registration (201 Response Code Expected)',
+                value: 'new'
+              },
+              {
+                label: 'Update Registration (200 Response Code Expected)',
+                value: 'update'
+              }
+            ]
+          },
+          default: 'new'
+
     input :udap_client_cert_pem,
           title: 'X.509 Client Certificate(s) (PEM Format)',
           description: %(

--- a/lib/udap_security_test_kit/registration_success_test.rb
+++ b/lib/udap_security_test_kit/registration_success_test.rb
@@ -61,7 +61,12 @@ module UDAPSecurityTestKit
 
       post(udap_registration_endpoint, body: reg_body, headers: reg_headers)
 
-      assert_response_status(201)
+      if udap_client_registration_status == 'new'
+        assert_response_status(201)
+      elsif udap_client_registration_status == 'update'
+        assert_response_status(200)
+      end
+
       assert_valid_json(response[:body])
       output udap_registration_response: response[:body]
     end

--- a/lib/udap_security_test_kit/registration_success_test.rb
+++ b/lib/udap_security_test_kit/registration_success_test.rb
@@ -70,7 +70,7 @@ module UDAPSecurityTestKit
       if udap_client_registration_status == 'new'
         assert_response_status(201)
       elsif udap_client_registration_status == 'update'
-        assert_response_status(200)
+        assert_response_status([200, 201])
       end
 
       assert_valid_json(response[:body])

--- a/lib/udap_security_test_kit/registration_success_test.rb
+++ b/lib/udap_security_test_kit/registration_success_test.rb
@@ -13,6 +13,12 @@ module UDAPSecurityTestKit
       The [UDAP IG Section 3.2.3](https://hl7.org/fhir/us/udap-security/STU1/registration.html#request-body) states:
       > If a new registration is successful, the Authorization Server SHALL return a registration response with a 201
       > Created HTTP response code as per Section 5.1 of UDAP Dynamic Client Registration
+
+      If the tester indicated this registration attempt represents a modification of an existing registration entry,
+      this test will expect a 200 response code instead, as indicated in
+      the [UDAP IG Section 3.4](https://hl7.org/fhir/us/udap-security/STU1/registration.html#modifying-and-cancelling-registrations):
+      > If the Authorization Server returns the same client_id in the registration response for a modification request,
+      > it SHOULD also return a 200 OK HTTP response code.
     )
 
     input :udap_client_cert_pem

--- a/lib/udap_security_test_kit/registration_success_test.rb
+++ b/lib/udap_security_test_kit/registration_success_test.rb
@@ -15,10 +15,12 @@ module UDAPSecurityTestKit
       > Created HTTP response code as per Section 5.1 of UDAP Dynamic Client Registration
 
       If the tester indicated this registration attempt represents a modification of an existing registration entry,
-      this test will expect a 200 response code instead, as indicated in
-      the [UDAP IG Section 3.4](https://hl7.org/fhir/us/udap-security/STU1/registration.html#modifying-and-cancelling-registrations):
+      the [UDAP IG Section 3.4](https://hl7.org/fhir/us/udap-security/STU1/registration.html#modifying-and-cancelling-registrations)
+      states:
       > If the Authorization Server returns the same client_id in the registration response for a modification request,
       > it SHOULD also return a 200 OK HTTP response code.
+
+      In this case, the test will require either a 201 or 200 response code to pass.
     )
 
     input :udap_client_cert_pem

--- a/lib/udap_security_test_kit/registration_success_test.rb
+++ b/lib/udap_security_test_kit/registration_success_test.rb
@@ -20,6 +20,7 @@ module UDAPSecurityTestKit
     input :udap_cert_iss
 
     input :udap_registration_endpoint
+    input :udap_client_registration_status
     input :udap_jwt_signing_alg
     input :udap_registration_requested_scope
     input :udap_registration_grant_type

--- a/spec/udap_security_test_kit/registration_success_test_spec.rb
+++ b/spec/udap_security_test_kit/registration_success_test_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessTest do
   let(:udap_registration_requested_scope) { 'system/*' }
   let(:udap_registration_grant_type) { 'client_credentials' }
   let(:udap_registration_certifications) { '' }
+  let(:udap_client_registration_status) { 'new' }
   let(:input) do
     {
       udap_client_cert_pem:,
@@ -30,7 +31,8 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessTest do
       udap_jwt_signing_alg:,
       udap_registration_requested_scope:,
       udap_registration_grant_type:,
-      udap_registration_certifications:
+      udap_registration_certifications:,
+      udap_client_registration_status:
     }
   end
 
@@ -48,21 +50,45 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessTest do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  it 'fails if response status is not 201' do
-    stub_request(:post, udap_registration_endpoint)
-      .to_return(status: 400, body: {}.to_json)
+  context 'when new client is being registered' do
+    it 'fails if response status is not 201' do
+      stub_request(:post, udap_registration_endpoint)
+        .to_return(status: 200, body: {}.to_json)
 
-    result = run(runnable, input)
+      result = run(runnable, input)
 
-    expect(result.result).to eq('fail')
+      expect(result.result).to eq('fail')
+    end
+
+    it 'passes when response status is 201' do
+      stub_request(:post, udap_registration_endpoint)
+        .to_return(status: 201, body: {}.to_json)
+
+      result = run(runnable, input)
+
+      expect(result.result).to eq('pass')
+    end
   end
 
-  it 'passes when response status is 201' do
-    stub_request(:post, udap_registration_endpoint)
-      .to_return(status: 201, body: {}.to_json)
+  context 'when existing client is updating its registration data' do
+    it 'fails if response status is not 200' do
+      stub_request(:post, udap_registration_endpoint)
+        .to_return(status: 201, body: {}.to_json)
 
-    result = run(runnable, input)
+      input[:udap_client_registration_status] = 'update'
+      result = run(runnable, input)
 
-    expect(result.result).to eq('pass')
+      expect(result.result).to eq('fail')
+    end
+
+    it 'passes when response status is 200' do
+      stub_request(:post, udap_registration_endpoint)
+        .to_return(status: 200, body: {}.to_json)
+
+      input[:udap_client_registration_status] = 'update'
+      result = run(runnable, input)
+
+      expect(result.result).to eq('pass')
+    end
   end
 end

--- a/spec/udap_security_test_kit/registration_success_test_spec.rb
+++ b/spec/udap_security_test_kit/registration_success_test_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessTest do
   end
 
   context 'when existing client is updating its registration data' do
-    it 'fails if response status is not 200' do
+    it 'fails if response status is not 200 or 201' do
       stub_request(:post, udap_registration_endpoint)
-        .to_return(status: 201, body: {}.to_json)
+        .to_return(status: 401, body: {}.to_json)
 
       input[:udap_client_registration_status] = 'update'
       result = run(runnable, input)
@@ -84,6 +84,16 @@ RSpec.describe UDAPSecurityTestKit::RegistrationSuccessTest do
     it 'passes when response status is 200' do
       stub_request(:post, udap_registration_endpoint)
         .to_return(status: 200, body: {}.to_json)
+
+      input[:udap_client_registration_status] = 'update'
+      result = run(runnable, input)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes when response status is 201' do
+      stub_request(:post, udap_registration_endpoint)
+        .to_return(status: 201, body: {}.to_json)
 
       input[:udap_client_registration_status] = 'update'
       result = run(runnable, input)


### PR DESCRIPTION
# Summary
Currently, the dynamic registration success tests assumes all registration attempts are for a new client and expect a 201 response code returned, per IG requirements. This PR allows testers to specify via a test input whether the registration tests are registering a new client or updating an existing client's data. For new clients, the registration success test will require a 201 response code returned; for updated clients, the test will require either a 200 or 201 response code, since the IG states that servers SHOULD (rather than SHALL) return a 200 code for a successful registration modification.

Even though the HL7 UDAP IG does not require servers to support registration modifications, adding support for this capability in the registration tests makes the testing process much easier for system that _do_ support this capability: testers no longer need to manually remove a client's registration entry on their authorization server, or procure a new certificate/issuer identity, to run registration tests more than once. Systems that do not support registration modifications would still be required to make any necessary adjustments so that a `201 Created` response is returned on successive registration success test runs. 

# Testing Guidance
Unit tests have been updated and are passing. Input instructions and test descriptions have also been updated and can be viewed in the web UI. 
