### PR TITLE
FI-3610 Add redirect_uri config to redirect test

### DIFF
--- a/lib/udap_security_test_kit/authorization_code_redirect_test.rb
+++ b/lib/udap_security_test_kit/authorization_code_redirect_test.rb
@@ -52,6 +52,10 @@ module UDAPSecurityTestKit
 
     receives_request :redirect
 
+    config options: {
+      redirect_uri: UDAPSecurityTestKit::UDAP_REDIRECT_URI
+    }
+
     def wait_message(auth_url)
       if config.options[:redirect_message_proc].present?
         return instance_exec(auth_url, &config.options[:redirect_message_proc])


### PR DESCRIPTION
# Summary
This PR adds a configuration for the `redirect_uri` to the authorization code redirect test to fix an integration bug when the redirect test is reused in another test kit. 

Prior to this change, the `redirect_uri` in the UDAP test kit was configured at the suite level but not at the test level. When the redirect test was reused in another test kit, that test kit needed to manually configure a `redirect_uri`, otherwise the URI would be blank and the test failed:

![image](https://github.com/user-attachments/assets/ef59a3e6-9709-4e24-9f05-b7af2d3fc83e)

However, even if that configuration is set in the other test kit, the redirect URI used by the authorization code redirect test must match the value submitted in the dynamic client registration test's [software statement](https://github.com/inferno-framework/udap-security-test-kit/blob/main/lib/udap_security_test_kit/software_statement_builder.rb), which is the constant `UDAPSecurityTestKit::UDAP_REDIRECT_URI`. 

Therefore, the `redirect_uri` path must be set and properly exported by the UDAP redirect test in order for the collective set of UDAP tests to work when imported by another test kit. 

# Testing Guidance

To reproduce the bug present in the latest UDAP release (0.10.2):

1. Clone the UDAP test kit and checkout `main` branch, which is currently aligned with the latest release
2. Run `git rev-parse --show-toplevel` in the UDAP directory to get the path to the repo for use in step 4
3. Clone the SMART-UDAP harmonization test kit and check out the branch `FI-3502-update-redirect-test`, which is in a [draft PR here](https://github.com/inferno-framework/smart-udap-harmonization-test-kit/pull/9)
4. In the SMART-UDAP test kit repo, configure a local override for the UDAP test kit gem using the path from step 2: `bundle config local.udap_security_test_kit </path/to/local/git/repository>`
5. In the SMART-UDAP Gemfile, update the branch value for `udap_security_test_kit` to be `main`
6. Run `bundle install` in the SMART-UDAP repo
7. Run the SMART-UDAP test kit as usual and navigate to `localhost:4567`
8. Select the SMART-UDAP test suite, then group 1.3 UDAP Authorization Code Authorization & Authentication
9. Run test 1.3.01 Authorization server redirects client to redirect URI. Put dummy inputs for all required inputs, except the authorization endpoint, which must be a valid URI
10. The User Action Required window should show up and indicate that it is waiting to receive a request at `` (blank URI)

To demonstrate the bug fix in this branch:
1. In the UDAP test kit repo, checkout this branch `FI-3610-redirect-config-fix`
2. In the SMART-UDAP Gemfile, update the branch value for `udap_security_test_kit` to be `FI-3610-redirect-config-fix`
3. Repeat steps 6-8 above
4. When the User Action Required window shows up, the redirect URI should match the value set in the UDAP test kit, where the constant `UDAPSecurityTestKit::UDAP_REDIRECT_URI` resolves to `#{Inferno::Application['base_url']}/custom/udap_security/redirect`, and the displayed value should be `http://localhost:4567/custom/udap_security/redirect`
