### PR TITLE
Typo fix in expired token error message

### DIFF
--- a/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
@@ -206,7 +206,7 @@ module UDAPSecurityTestKit
       response.format = :json
       response.body = FHIR::OperationOutcome.new(
         issue: FHIR::OperationOutcome::Issue.new(severity: 'fatal', code: 'expired',
-                                                 details: FHIR::CodeableConcept.new(text: "#{type}has expired"))
+                                                 details: FHIR::CodeableConcept.new(text: "#{type} has expired"))
       ).to_json
     end
 

--- a/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
       header('Authorization', "Bearer #{expired_token}")
       get(access_url)
       expect(last_response.status).to eq(401)
+      expect(last_response.body).to match(/Bearer token has expired/)
 
       result = results_repo.find(result.id)
       expect(result.result).to eq('wait')


### PR DESCRIPTION
# Summary

Fix a minor typo in the expired token error message

# Testing Guidance

Run the Client suite on localhost:4567 against the server suite as described in the client suite description, but instead of using the access token obtained by the server suite use the following expired access token on the postman read request: `eyJjbGllbnRfaWQiOiJhSFIwY0RvdkwyeHZZMkZzYUc5emREbzBOVFkzTDJOMWMzUnZiUzkxWkdGd1gzTmxZM1Z5YVhSNUwyWm9hWEkiLCJleHBpcmF0aW9uIjoxNzQ2NjQ3MzcsIm5vbmNlIjoiMjY2YjczODE0YjkyODk0ZiJ9`. Verify that the returned error text has a space between "token" and "has".
