### PR TITLE
FI-4027: Introspection simulation

### DIFF
--- a/lib/udap_security_test_kit/client_suite.rb
+++ b/lib/udap_security_test_kit/client_suite.rb
@@ -1,6 +1,7 @@
 require_relative 'endpoints/mock_udap_server/registration_endpoint'
 require_relative 'endpoints/mock_udap_server/authorization_endpoint'
 require_relative 'endpoints/mock_udap_server/token_endpoint'
+require_relative 'endpoints/mock_udap_server/introspection_endpoint'
 require_relative 'endpoints/echoing_fhir_responder_endpoint'
 require_relative 'urls'
 require_relative 'client_suite/registration_ac_group'
@@ -61,6 +62,7 @@ module UDAPSecurityTestKit
     suite_endpoint :post, REGISTRATION_PATH, MockUDAPServer::RegistrationEndpoint
     suite_endpoint :get, AUTHORIZATION_PATH, MockUDAPServer::AuthorizationEndpoint
     suite_endpoint :post, AUTHORIZATION_PATH, MockUDAPServer::AuthorizationEndpoint
+    suite_endpoint :post, INTROSPECTION_PATH, MockUDAPServer::IntrospectionEndpoint
     suite_endpoint :post, TOKEN_PATH, MockUDAPServer::TokenEndpoint
     suite_endpoint :get, FHIR_PATH, EchoingFHIRResponderEndpoint
     suite_endpoint :post, FHIR_PATH, EchoingFHIRResponderEndpoint

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
@@ -380,15 +380,5 @@ module UDAPSecurityTestKit
         Rack::Utils.parse_query(inferno_request.request_body)
       end
     end
-
-    def token_request_details(inferno_request)
-      return unless inferno_request.present?
-
-      if inferno_request.verb.downcase == 'get'
-        Rack::Utils.parse_query(inferno_request.request_body)
-      elsif inferno_request.verb.downcase == 'post'
-        JSON.parse(inferno_request.request_body)
-      end
-    end
   end
 end

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
@@ -165,7 +165,7 @@ module UDAPSecurityTestKit
         end
       return unless token_to_decode.present?
 
-      JSON.parse(Base64.urlsafe_decode64(token))
+      JSON.parse(Base64.urlsafe_decode64(token_to_decode))
     rescue JSON::ParserError
       nil
     end
@@ -372,10 +372,22 @@ module UDAPSecurityTestKit
     end
 
     def authorization_code_request_details(inferno_request)
+      return unless inferno_request.present?
+
       if inferno_request.verb.downcase == 'get'
         Rack::Utils.parse_query(URI(inferno_request.url)&.query)
       elsif inferno_request.verb.downcase == 'post'
         Rack::Utils.parse_query(inferno_request.request_body)
+      end
+    end
+
+    def token_request_details(inferno_request)
+      return unless inferno_request.present?
+
+      if inferno_request.verb.downcase == 'get'
+        Rack::Utils.parse_query(inferno_request.request_body)
+      elsif inferno_request.verb.downcase == 'post'
+        JSON.parse(inferno_request.request_body)
       end
     end
   end

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
@@ -29,6 +29,7 @@ module UDAPSecurityTestKit
         token_endpoint: base_url + TOKEN_PATH,
         token_endpoint_auth_methods_supported: ['private_key_jwt'],
         token_endpoint_auth_signing_alg_values_supported: ['RS256', 'RS384', 'ES384'],
+        introspection_endpoint: base_url + INTROSPECTION_PATH,
         signed_metadata: udap_signed_metadata_jwt(base_url)
       }.to_json
 

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server/introspection_endpoint.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server/introspection_endpoint.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../tags'
+require_relative '../mock_udap_server'
+require_relative 'udap_introspection_response_creation'
+
+module UDAPSecurityTestKit
+  module MockUDAPServer
+    class IntrospectionEndpoint < Inferno::DSL::SuiteEndpoint
+      include UDAPIntrospectionResponseCreation
+
+      def test_run_identifier
+        MockUDAPServer.issued_token_to_client_id(request.params[:token])
+      end
+
+      def make_response
+        response.body = make_udap_introspection_response.to_json
+        response.headers['Cache-Control'] = 'no-store'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        response.content_type = 'application/json'
+        response.status = 200
+      end
+
+      def update_result
+        nil # never update for now
+      end
+
+      def tags
+        [INTROSPECTION_TAG, UDAP_TAG]
+      end
+    end
+  end
+end

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
@@ -1,0 +1,71 @@
+require_relative '../../tags'
+require_relative '../mock_udap_server'
+
+module UDAPSecurityTestKit
+  module MockUDAPServer
+    module UDAPIntrospectionResponseCreation
+      def make_udap_introspection_response # rubocop:disable Metrics/CyclomaticComplexity
+        target_token = request.params[:token]
+        introspection_inactive_response_body = { active: false }
+
+        return introspection_inactive_response_body if MockUDAPServer.token_expired?(target_token)
+
+        token_requests = Inferno::Repositories::Requests.new.tagged_requests(test_run.test_session_id, [TOKEN_TAG])
+        original_response_body = nil
+        original_token_request = token_requests.find do |request|
+          next unless request.status == 200
+
+          original_response_body = JSON.parse(request.response_body)
+          original_response_body['access_token'] == target_token
+        end
+        return introspection_inactive_response_body unless original_token_request.present?
+
+        decoded_token = MockUDAPServer.decode_token(target_token)
+        introspection_active_response_body = {
+          active: true,
+          client_id: decoded_token['client_id'],
+          exp: decoded_token['expiration']
+        }
+        original_response_body.each do |element, value|
+          next if ['access_token', 'refresh_token', 'token_type', 'expires_in'].include?(element)
+          next if introspection_active_response_body.key?(element)
+
+          introspection_active_response_body[element] = value
+        end
+        unless introspection_active_response_body.key?('scope')
+          introspection_active_response_body['scope'] = requested_scope(original_token_request)
+        end
+        if original_response_body.key?('id_token')
+          user_claims, _header = JWT.decode(original_response_body['id_token'], nil, false)
+          introspection_active_response_body['iss'] = user_claims['iss']
+          introspection_active_response_body['sub'] = user_claims['sub']
+          introspection_active_response_body['fhirUser'] = user_claims['fhirUser'] if user_claims['fhirUser'].present?
+        end
+
+        introspection_active_response_body
+      end
+
+      def requested_scope(token_request)
+        # token request
+
+        original_request_body = MockUDAPServer.token_request_details(token_request)
+        return original_request_body['scope'] if original_request_body['scope'].present?
+
+        # authorization request
+        authorization_request = MockUDAPServer.authorization_request_for_code(original_request_body['code'],
+                                                                              test_run.test_session_id)
+        auth_code_request_inputs = MockUDAPServer.authorization_code_request_details(authorization_request)
+        return auth_code_request_inputs['scope'] if auth_code_request_inputs&.dig('scope').present?
+
+        # registration request
+        registered_software_statement = MockUDAPServer.udap_registration_software_statement(test_run.test_session_id)
+        if registered_software_statement.present?
+          registration_body, _registration_header = JWT.decode(registered_software_statement, nil, false)
+          return registration_body['scope'] if registration_body['scope'].present?
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
@@ -47,8 +47,7 @@ module UDAPSecurityTestKit
 
       def requested_scope(token_request)
         # token request
-
-        original_request_body = MockUDAPServer.token_request_details(token_request)
+        original_request_body = Rack::Utils.parse_query(token_request.request_body)
         return original_request_body['scope'] if original_request_body['scope'].present?
 
         # authorization request

--- a/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server/udap_introspection_response_creation.rb
@@ -57,6 +57,7 @@ module UDAPSecurityTestKit
         return auth_code_request_inputs['scope'] if auth_code_request_inputs&.dig('scope').present?
 
         # registration request
+        # not looking in registration response since the simulation currently echoes the requested scopes
         registered_software_statement = MockUDAPServer.udap_registration_software_statement(test_run.test_session_id)
         if registered_software_statement.present?
           registration_body, _registration_header = JWT.decode(registered_software_statement, nil, false)

--- a/lib/udap_security_test_kit/tags.rb
+++ b/lib/udap_security_test_kit/tags.rb
@@ -3,6 +3,7 @@
 module UDAPSecurityTestKit
   REGISTRATION_TAG = 'registration'
   AUTHORIZATION_TAG = 'authorization'
+  INTROSPECTION_TAG = 'introspection'
   TOKEN_TAG = 'token'
   UDAP_TAG = 'udap'
   ACCESS_TAG = 'access'

--- a/lib/udap_security_test_kit/urls.rb
+++ b/lib/udap_security_test_kit/urls.rb
@@ -8,6 +8,7 @@ module UDAPSecurityTestKit
   AUTH_SERVER_PATH = '/auth'
   REGISTRATION_PATH = "#{AUTH_SERVER_PATH}/register".freeze
   AUTHORIZATION_PATH = "#{AUTH_SERVER_PATH}/authorization".freeze
+  INTROSPECTION_PATH = "#{AUTH_SERVER_PATH}/introspect".freeze
   TOKEN_PATH = "#{AUTH_SERVER_PATH}/token".freeze
   RESUME_PASS_PATH = '/resume_pass'
   RESUME_FAIL_PATH = '/resume_fail'
@@ -39,6 +40,10 @@ module UDAPSecurityTestKit
 
     def client_authorization_url
       @client_authorization_url ||= client_base_url + AUTHORIZATION_PATH
+    end
+
+    def client_introspection_url
+      @client_introspection_url ||= client_base_url + INTROSPECTION_PATH
     end
 
     def client_token_url

--- a/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
       test_session_id: test_session.id,
       request_body: body,
       status: 200,
+      verb: 'post',
       tags: [UDAPSecurityTestKit::REGISTRATION_TAG, UDAPSecurityTestKit::UDAP_TAG]
     )
   end
@@ -240,6 +241,7 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
       request_body: URI.encode_www_form(request_body),
       response_body: response_body.to_json,
       status: 200,
+      verb: 'post',
       tags: [UDAPSecurityTestKit::TOKEN_TAG, UDAPSecurityTestKit::UDAP_TAG, UDAPSecurityTestKit::AUTHORIZATION_CODE_TAG]
     )
   end


### PR DESCRIPTION
# Summary

Add an introspection endpoint simulation to the UDAP client tests

# Testing Guidance

- Run added `rspec` tests
- Run the client tests against the server tests and then while the client tests are still waiting, use postman or another tool to make a token introspection request against `http://localhost:4567/custom/udap_security_client/auth/introspect` using the token that the server tests got back and verify that details like the scope are included in the response.
