### PR TITLE
Sync token decoding error handling with smart

### DIFF
--- a/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
+++ b/lib/udap_security_test_kit/endpoints/mock_udap_server.rb
@@ -167,7 +167,7 @@ module UDAPSecurityTestKit
       return unless token_to_decode.present?
 
       JSON.parse(Base64.urlsafe_decode64(token_to_decode))
-    rescue JSON::ParserError
+    rescue StandardError
       nil
     end
 


### PR DESCRIPTION
# Summary

Previously, if a non url-safe Base64 encoded string were sent as a bearer token, Inferno would spit out a nasty error as a part of the 500 response indicating no session could be found. Now, the same 500 response just indicates that the session cannot be found.

# Testing Guidance

Follow the UDAP client suite demonstration instructions for making a FHIR request while the client tests are waiting, but send a bearer token like `WRONG` and verify that the error response is clean.