### PR TITLE
gem dependency updates and addressing rubocop offenses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,42 @@ PATH
   remote: .
   specs:
     udap_security_test_kit (0.12.0)
-      inferno_core (~> 1.0, >= 1.0.2)
+      inferno_core (~> 1.2, >= 1.2.2)
       jwt (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.10)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    auth-sanitizer (0.1.2)
+      version_gem (~> 1.1, >= 1.1.9)
     base62-rb (0.3.1)
     base64 (0.3.0)
     bcp47 (0.3.3)
       i18n
-    bigdecimal (3.2.2)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
     blueprinter (0.25.2)
-    byebug (12.0.0)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
-    connection_pool (2.5.3)
-    crack (1.0.0)
+    connection_pool (3.0.2)
+    crack (1.0.1)
       bigdecimal
       rexml
     csv (3.3.5)
@@ -35,14 +45,15 @@ GEM
     database_cleaner-sequel (1.99.0)
       database_cleaner (~> 1.99.0)
       sequel
-    date (3.4.1)
+    date (3.5.1)
     date_time_precision (0.8.1)
-    debug (1.11.0)
+    debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    drb (2.2.3)
     dry-auto_inject (1.0.1)
       dry-core (~> 1.0)
       zeitwerk (~> 2.6)
@@ -60,12 +71,13 @@ GEM
       dry-configurable (~> 1.0, < 2)
       dry-core (~> 1.0, < 2)
       dry-inflector (~> 1.0, < 2)
-    dry-transformer (1.0.1)
+    dry-transformer (1.1.0)
+      bigdecimal
       zeitwerk (~> 2.6)
-    erb (5.0.1)
-    factory_bot (6.5.4)
+    erb (6.0.4)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -81,24 +93,24 @@ GEM
     faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.1)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
-    fhir_client (6.0.0)
+    fhir_client (6.2.0)
       activesupport (>= 3)
-      addressable (>= 2.3)
+      addressable (>= 2.9.0)
       fhir_dstu2_models (>= 1.1.1)
-      fhir_models (>= 5.0.0)
+      fhir_models (>= 5.1.0)
       fhir_stu3_models (>= 3.1.1)
-      nokogiri (>= 1.10.4)
-      oauth2 (~> 1.1)
-      rack (>= 1.5)
+      nokogiri (>= 1.19.1)
+      oauth2 (~> 2.0)
+      rack (>= 2.2.23)
       rest-client (~> 2.0)
       tilt (>= 1.1)
     fhir_dstu2_models (1.2.0)
@@ -106,11 +118,11 @@ GEM
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
       nokogiri (>= 1.11.4)
-    fhir_models (5.0.0)
+    fhir_models (5.1.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
-      nokogiri (>= 1.11.4)
+      nokogiri (>= 1.19.1)
     fhir_stu3_models (3.2.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
@@ -126,19 +138,22 @@ GEM
       mustermann (~> 1.0)
       mustermann-contrib (~> 1.0)
       rack (~> 2.0)
-    hanami-utils (2.2.0)
+    hanami-utils (2.3.0)
+      bigdecimal (~> 3.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       dry-transformer (~> 1.0, < 2)
     hansi (0.2.1)
-    hashdiff (1.2.0)
+    hashdiff (1.2.1)
+    hashie (5.1.0)
+      logger
     http-accept (1.7.0)
-    http-cookie (1.0.8)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.0.2)
-      activesupport (~> 6.1.7.5)
+    inferno_core (1.2.2)
+      activesupport (~> 7.2.3.1)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
       concurrent-ruby (= 1.3.4)
@@ -149,13 +164,13 @@ GEM
       dry-core (= 1.0.0)
       dry-inflector (= 1.0.0)
       dry-system (= 1.0.0)
-      faraday (~> 1.2)
+      faraday (~> 1.10.5)
       faraday_middleware (~> 1.2)
-      fhir_client (>= 5.0.3)
-      fhir_models (>= 4.2.2)
+      fhir_client (>= 6.2.0)
+      fhir_models (>= 5.1.0)
       hanami-controller (= 2.0.0)
       hanami-router (= 2.0.0)
-      kramdown (~> 2.5.1)
+      kramdown (~> 2.5.2)
       kramdown-parser-gfm (~> 1.1.0)
       mutex_m (~> 0.3.0)
       oj (= 3.11.0)
@@ -168,18 +183,19 @@ GEM
       sequel (~> 5.42.0)
       sidekiq (~> 7.2.4)
       sqlite3 (~> 1.4)
-      thor (~> 1.2.1)
+      thor (~> 1.4)
       tty-markdown (~> 0.7.1)
-    io-console (0.8.0)
-    irb (1.15.2)
+    io-console (0.8.2)
+    irb (1.18.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.12.2)
+    json (2.19.5)
     jwt (2.10.2)
       base64
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.5)
@@ -189,11 +205,10 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0715)
-    minitest (5.25.5)
-    multi_json (1.17.0)
-    multi_xml (0.7.2)
-      bigdecimal (~> 3.1)
+    mime-types-data (3.2026.0414)
+    minitest (5.27.0)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
@@ -202,116 +217,138 @@ GEM
       mustermann (= 1.1.2)
     mutex_m (0.3.0)
     netrc (0.11.0)
-    nio4r (2.7.4)
-    nokogiri (1.18.9-arm64-darwin)
+    nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    oauth2 (1.4.11)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    oauth2 (2.0.19)
+      auth-sanitizer (~> 0.1)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
     oj (3.11.0)
-    parallel (1.27.0)
-    parser (3.3.8.0)
+    parallel (2.1.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pp (0.6.2)
+    pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
-    pry (0.15.2)
+    prism (1.9.0)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
-    psych (5.2.6)
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
+    psych (5.3.1)
       date
       stringio
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (2.2.23)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.1.1)
-    rake (13.3.0)
-    rdoc (6.14.1)
+    rake (13.4.2)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
-    redis-client (0.25.1)
+      tsort
+    redis-client (0.29.0)
       connection_pool
-    regexp_parser (2.10.0)
-    reline (0.6.1)
+    regexp_parser (2.12.0)
+    reline (0.6.3)
       io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.1)
+    rexml (3.4.4)
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
-    rouge (4.5.2)
-    rspec (3.13.1)
+    rouge (4.7.0)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.4)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.5)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.4)
-    rubocop (1.77.0)
+    rspec-support (3.13.7)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.45.1, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.45.1)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-rspec (3.6.0)
+      prism (~> 1.7)
+    rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
+    securerandom (0.4.1)
     sequel (5.42.0)
     sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
+    snaky_hash (2.0.4)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
-    stringio (3.1.7)
+    stringio (3.2.0)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
-    thor (1.2.2)
-    tilt (2.6.1)
+    thor (1.5.0)
+    tilt (2.7.0)
+    tsort (0.2.0)
     tty-color (0.6.0)
     tty-markdown (0.7.2)
       kramdown (>= 1.16.2, < 3.0)
@@ -325,18 +362,24 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    webmock (3.25.1)
+    version_gem (1.1.9)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.7.3)
+    zeitwerk (2.8.0)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-23
-  arm64-darwin-24
-  x86_64-darwin-20
-  x86_64-linux
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   database_cleaner-sequel (~> 1.8)
@@ -350,5 +393,157 @@ DEPENDENCIES
   udap_security_test_kit!
   webmock (~> 3.11)
 
+CHECKSUMS
+  activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  auth-sanitizer (0.1.2) sha256=29f7638d74b2a19ff890008f1561165668a78969a4d90bc85e991128825a7c03
+  base62-rb (0.3.1) sha256=24e084c7e4101366ced80facf46913e4fe975b18409c55772747f44d18bf6aa0
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bcp47 (0.3.3) sha256=e203e81a8f94425a0cbd3b2f05f466e5b321f38697412ba9cd121e02382d0825
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
+  blueprinter (0.25.2) sha256=398b8b071e18734a2b10c66c45d0c1066a498c71f7130e5117c361f8ef5e894b
+  byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  concurrent-ruby (1.3.4) sha256=d4aa926339b0a86b5b5054a0a8c580163e6f5dcbdfd0f4bb916b1a2570731c32
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  database_cleaner (1.99.0) sha256=4854c518ed36fae7ea8961993ff3cfe7c0a0434c4762ab2f0026075adbd2d1b2
+  database_cleaner-sequel (1.99.0) sha256=b0cdc1f3ef84f783daefa5101ff9b7444cc2070a572cbbd7ce14e6b30090e427
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  date_time_precision (0.8.1) sha256=77547764faca6c73761b9c10d7a226fd29de44ef42538c644da01680a1ee22aa
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  dry-auto_inject (1.0.1) sha256=7dc28d57ea22947f6162ca897417e951e0f88ade11dff17fccd0de955b5e4d14
+  dry-configurable (1.0.0) sha256=1e9e41b616f7be96fe06cc124dde46aff695a32392f6f898fdce2dc522184998
+  dry-container (0.10.0) sha256=fd4b4c6e49d372ed0b159a9aaa484190eb9610f5369923ab4791a4b299b91aa9
+  dry-core (1.0.0) sha256=7a92099870967f0d2c9997950608cb8bb622dafeea20b2fe1dd49e9ba1d0f305
+  dry-inflector (1.0.0) sha256=6ad22361ca2d6f3f001ae3037ffcfea01163f644280d13a9195d3c3a94dd1626
+  dry-system (1.0.0) sha256=ffa2e796cbdad1c71960cd70de16b8079fb85090aa27c0a9b97f9dcce37e5595
+  dry-transformer (1.1.0) sha256=87bfe22a708aa69f3e6e76a6119aba0b42999f154e4fe7c261d4673720534da3
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  factory_bot (6.6.0) sha256=1fc1b3b5620ec980a6a27aec1b6ec8c250ca82962e970e8a40f93e8d388d4b89
+  faraday (1.10.5) sha256=b144f1d2b045652fa820b5f532723e1643cc28b93dae911d784e5c5f88e8f6ed
+  faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
+  faraday-em_synchrony (1.0.1) sha256=bf3ce45dcf543088d319ab051f80985ea6d294930635b7a0b966563179f81750
+  faraday-excon (1.1.0) sha256=b055c842376734d7f74350fe8611542ae2000c5387348d9ba9708109d6e40940
+  faraday-httpclient (1.0.1) sha256=4c8ff1f0973ff835be8d043ef16aaf54f47f25b7578f6d916deee8399a04d33b
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (1.0.2) sha256=63992efea42c925a20818cf3c0830947948541fdcf345842755510d266e4c682
+  faraday-net_http_persistent (1.2.0) sha256=0b0cbc8f03dab943c3e1cc58d8b7beb142d9df068b39c718cd83e39260348335
+  faraday-patron (1.0.0) sha256=dc2cd7b340bb3cc8e36bcb9e6e7eff43d134b6d526d5f3429c7a7680ddd38fa7
+  faraday-rack (1.0.0) sha256=ef60ec969a2bb95b8dbf24400155aee64a00fc8ba6c6a4d3968562bcc92328c0
+  faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
+  faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
+  fhir_client (6.2.0) sha256=da740984792e464948e87a5a6273b3f24fb67c788a055be67399db14e7f929bd
+  fhir_dstu2_models (1.2.0) sha256=efb8be21a0caef112ebc90a55762bacde1cbd457e13567895579c79dbcb1b16f
+  fhir_models (5.1.0) sha256=5139aadcc372648847d648b2415911c4a2c053e57b3f02d2637ec6e3bdb2013f
+  fhir_stu3_models (3.2.0) sha256=10479490abad0c67b4d9cc8e37a8bc9e7e943a9e7e75270ebb14bf3ef9ab43ab
+  hanami-controller (2.0.0) sha256=73102e86bcdd4f3e65f0c103ffa31fed6b2c8c95f9e10c71055273a78ac10ec2
+  hanami-router (2.0.0) sha256=e5b261933fdf04aa06d456dd4f5e61e0dc760201c7b55b80c2d6f18a2d9adbcd
+  hanami-utils (2.3.0) sha256=aa00f6c377ab4ad2cbe57d989781bace348c9f234201bc60715058dc6e220999
+  hansi (0.2.1) sha256=7e27dfd729f1692a3a7690fc0ef3af9d5e3cfc0285bb135cae7e56180e4805db
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
+  http-accept (1.7.0) sha256=c626860682bfbb3b46462f8c39cd470fd7b0584f61b3cc9df5b2e9eb9972a126
+  http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  inferno_core (1.2.2) sha256=1ad8cfcb53a3c55723b4b802d467b7ff638a86ee81df4e425aba36c74bcd4284
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  jwt (2.10.2) sha256=31e1ee46f7359883d5e622446969fe9c118c3da87a0b1dca765ce269c3a0c4f4
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mustermann (1.1.2) sha256=7b64de2f39ae6b623b6d4f7d2ced10d3442817ca9bb6200cf7bff3b9f6447b7e
+  mustermann-contrib (1.1.2) sha256=a67de5cb24a0e91a7adbb2414cda416d6baa34ccd3cc32ce12099141c9dca699
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
+  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  oauth2 (2.0.19) sha256=175e12c18c3e786bd5c0f30a3235d17594ea36935d17aac5c1296497c0a42613
+  oj (3.11.0) sha256=470d6ac425efd19c526ecea1cabb0219dd8bbcbdeeec57bd45a803b5e082ab5b
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  pastel (0.8.0) sha256=481da9fb7d2f6e6b1a08faf11fa10363172dc40fd47848f096ae21209f805a75
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  puma (5.6.9) sha256=20701b2451080ec8d6d78d2e4b5a2913e6d0b865a51d704a4d60db8fd39a4228
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (2.2.23) sha256=a8fe9d7e07064770b8ec123663fded8a59ef7e2b6db5cda7173d45a5718ab69c
+  rack-test (1.1.0) sha256=154161f40f162b1c009a655b7b0c5de3a3102cc6d7d2e94b64e1f46ace800866
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  redis-client (0.29.0) sha256=0c65bf1f8f6dca22063ddb085c0bb2054feef6f03a84869f4161b18a9a15bea3
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rest-client (2.1.0) sha256=35a6400bdb14fae28596618e312776c158f7ebbb0ccad752ff4fa142bf2747e3
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  roo (2.10.1) sha256=cbb43bc955f9c110e74b721c835fb9bd3515b63af88ec709ac87fbf30f8be70e
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  sequel (5.42.0) sha256=d7309e3f792372ffad1d06a7ff826bdefa86623a055bc2f57b344eca5c77848b
+  sidekiq (7.2.4) sha256=810e02f486ce5e102dbe6b71a19b4bf839791e11b74942ec38f5e1a6d44a0778
+  snaky_hash (2.0.4) sha256=2b12758c57defa6796341a1620f84b1a23737421d8d7e2575d0550b53cc4fece
+  sqlite3 (1.7.3-aarch64-linux) sha256=0ccb8c001cd2617f4801a2c816142d3c9bc299e3f3e0f49e03812f3610b0891c
+  sqlite3 (1.7.3-arm-linux) sha256=eb653026d44f8502b74564e585245485a5667d72f8888854e53c561f816541b0
+  sqlite3 (1.7.3-arm64-darwin) sha256=b956160cc882d2568f332f915c9fe27cae9a4521b202d6e7ea540171c88e4600
+  sqlite3 (1.7.3-x86_64-darwin) sha256=b88e117ae14b2c5b61a7eb14da24b3b0e93cd3e1c17774ff3b6e5a03ffe4e5b7
+  sqlite3 (1.7.3-x86_64-linux) sha256=522a3285660dec8253465880c97980e873db0d79060900be8d14194217a3ee73
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strings (0.2.1) sha256=933293b3c95cf85b81eb44b3cf673e3087661ba739bbadfeadf442083158d6fb
+  strings-ansi (0.2.0) sha256=90262d760ea4a94cc2ae8d58205277a343409c288cbe7c29416b1826bd511c88
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tty-color (0.6.0) sha256=6f9c37ca3a4e2367fb2e6d09722762647d6f455c111f05b59f35730eeb24332a
+  tty-markdown (0.7.2) sha256=1ed81db97028d006ba81e2cfd9fe0a04b0eb28650ad0d4086ed6e5627f4ac511
+  tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  udap_security_test_kit (0.12.0)
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  unicode_utils (1.4.0) sha256=b922d0cf2313b6b7136ada6645ce7154ffc86418ca07d53b058efe9eb72f2a40
+  version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+  zeitwerk (2.8.0) sha256=474d0a1d2429f635af7c4574f5ddbce0d0cfc286067c7515858b93a26b4f3e3d
+
 BUNDLED WITH
-   2.5.3
+  4.0.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.1.2)
     blueprinter (0.25.2)
     byebug (13.0.0)
       reline (>= 0.6.0)
@@ -138,8 +138,7 @@ GEM
       mustermann (~> 1.0)
       mustermann-contrib (~> 1.0)
       rack (~> 2.0)
-    hanami-utils (2.3.0)
-      bigdecimal (~> 3.1)
+    hanami-utils (2.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       dry-transformer (~> 1.0, < 2)
@@ -402,7 +401,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcp47 (0.3.3) sha256=e203e81a8f94425a0cbd3b2f05f466e5b321f38697412ba9cd121e02382d0825
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   blueprinter (0.25.2) sha256=398b8b071e18734a2b10c66c45d0c1066a498c71f7130e5117c361f8ef5e894b
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
@@ -446,7 +445,7 @@ CHECKSUMS
   fhir_stu3_models (3.2.0) sha256=10479490abad0c67b4d9cc8e37a8bc9e7e943a9e7e75270ebb14bf3ef9ab43ab
   hanami-controller (2.0.0) sha256=73102e86bcdd4f3e65f0c103ffa31fed6b2c8c95f9e10c71055273a78ac10ec2
   hanami-router (2.0.0) sha256=e5b261933fdf04aa06d456dd4f5e61e0dc760201c7b55b80c2d6f18a2d9adbcd
-  hanami-utils (2.3.0) sha256=aa00f6c377ab4ad2cbe57d989781bace348c9f234201bc60715058dc6e220999
+  hanami-utils (2.2.0) sha256=7884ed3ef637697487d7cb57045adec3325b9273c550a34b0d0f0332ccee5f5a
   hansi (0.2.1) sha256=7e27dfd729f1692a3a7690fc0ef3af9d5e3cfc0285bb135cae7e56180e4805db
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
@@ -546,4 +545,4 @@ CHECKSUMS
   zeitwerk (2.8.0) sha256=474d0a1d2429f635af7c4574f5ddbce0d0cfc286067c7515858b93a26b4f3e3d
 
 BUNDLED WITH
-  4.0.7
+   2.5.3

--- a/lib/udap_security_test_kit/common_assertions.rb
+++ b/lib/udap_security_test_kit/common_assertions.rb
@@ -7,7 +7,7 @@ module CommonAssertions
 
     assert values.is_a?(Array), "`#{field}` should be an Array, but found #{values.class.name}"
 
-    non_string_values = values.reject { |value| value.is_a?(String) } # rubocop:disable Style/SelectByKind
+    non_string_values = values.grep_v(String)
 
     assert non_string_values.blank?,
            "`#{field}` should be an Array of strings, but found

--- a/lib/udap_security_test_kit/common_assertions.rb
+++ b/lib/udap_security_test_kit/common_assertions.rb
@@ -7,7 +7,7 @@ module CommonAssertions
 
     assert values.is_a?(Array), "`#{field}` should be an Array, but found #{values.class.name}"
 
-    non_string_values = values.reject { |value| value.is_a?(String) }
+    non_string_values = values.reject { |value| value.is_a?(String) } # rubocop:disable Style/SelectByKind
 
     assert non_string_values.blank?,
            "`#{field}` should be an Array of strings, but found

--- a/lib/udap_security_test_kit/grant_types_supported_field_test.rb
+++ b/lib/udap_security_test_kit/grant_types_supported_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class GrantTypesSupportedFieldTest < Inferno::Test
     title 'grant_types_supported field'
     id :udap_grant_types_supported_field

--- a/lib/udap_security_test_kit/reg_endpoint_jwt_signing_alg_values_supported_field_test.rb
+++ b/lib/udap_security_test_kit/reg_endpoint_jwt_signing_alg_values_supported_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class RegEndpointJWTSigningAlgValuesSupportedFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/lib/udap_security_test_kit/scopes_supported_field_test.rb
+++ b/lib/udap_security_test_kit/scopes_supported_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class ScopesSupportedFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/lib/udap_security_test_kit/token_endpoint_auth_signing_alg_values_supported_field_test.rb
+++ b/lib/udap_security_test_kit/token_endpoint_auth_signing_alg_values_supported_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class TokenEndpointAuthSigningAlgValuesSupportedFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/lib/udap_security_test_kit/udap_certifications_required_field_test.rb
+++ b/lib/udap_security_test_kit/udap_certifications_required_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class UDAPCertificationsRequiredFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/lib/udap_security_test_kit/udap_certifications_supported_field_test.rb
+++ b/lib/udap_security_test_kit/udap_certifications_supported_field_test.rb
@@ -1,6 +1,7 @@
 require_relative 'common_assertions'
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class UDAPCertificationsSupportedFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/lib/udap_security_test_kit/udap_profiles_supported_field_test.rb
+++ b/lib/udap_security_test_kit/udap_profiles_supported_field_test.rb
@@ -2,6 +2,7 @@ require_relative 'common_assertions'
 
 module UDAPSecurityTestKit
   extend CommonAssertions
+
   class UDAPProfilesSupportedFieldTest < Inferno::Test
     include Inferno::DSL::Assertions
 

--- a/spec/udap_security_test_kit/client_suite/authorization_request_verification_test_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/authorization_request_verification_test_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::UDAPClientAppLaunchAuthorizationRequestVerification do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { described_class }
   let(:test_session) do # overriden to add suite options

--- a/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { suite.children[2].children[0] } # access test
   let(:results_repo) { Inferno::Repositories::Results.new }

--- a/spec/udap_security_test_kit/client_suite/registration_ac_verification_test_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/registration_ac_verification_test_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::UDAPClientRegistrationAuthorizationCodeVerification do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { described_class }
   let(:test_session) do # overriden to add suite options

--- a/spec/udap_security_test_kit/client_suite/registration_cc_verification_test_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/registration_cc_verification_test_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::UDAPClientRegistrationClientCredentialsVerification do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { described_class }
   let(:test_session) do # overriden to add suite options

--- a/spec/udap_security_test_kit/client_suite/registration_interaction_test_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/registration_interaction_test_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::UDAPClientRegistrationInteraction, :request do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { described_class }
   let(:results_repo) { Inferno::Repositories::Results.new }

--- a/spec/udap_security_test_kit/client_suite/token_request_ac_verification_test_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/token_request_ac_verification_test_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UDAPSecurityTestKit::UDAPClientTokenRequestAuthorizationCodeVerification do # rubocop:disable RSpec/SpecFilePathFormat
   include UDAPSecurityTestKit::URLs
+
   let(:suite_id) { 'udap_security_client' }
   let(:test) { described_class }
   let(:test_session) do # overriden to add suite options

--- a/spec/udap_security_test_kit/udap_jwt_validator_spec.rb
+++ b/spec/udap_security_test_kit/udap_jwt_validator_spec.rb
@@ -44,9 +44,6 @@ RSpec.describe UDAPSecurityTestKit::UDAPJWTValidator do # rubocop:disable RSpec/
         trust_anchor_certs
       )
       expect(validation_result[:success]).to be true
-      unless validation_result[:success]
-        puts "Trust chain validation error message: #{validation_result[:error_message]}" # rubocop:disable RSpec/Output
-      end
     end
 
     it 'returns that trust chain cannot be verified if CRL endpoint not accessible' do
@@ -91,9 +88,6 @@ RSpec.describe UDAPSecurityTestKit::UDAPJWTValidator do # rubocop:disable RSpec/
       )
 
       expect(validation_result[:success]).to be true
-      unless validation_result[:success]
-        puts "JWT Signature validation error message: #{validation_result[:error_message]}" # rubocop:disable RSpec/Output
-      end
     end
   end
 end

--- a/spec/udap_security_test_kit/udap_jwt_validator_spec.rb
+++ b/spec/udap_security_test_kit/udap_jwt_validator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UDAPSecurityTestKit::UDAPJWTValidator do # rubocop:disable RSpec/
       )
       expect(validation_result[:success]).to be true
       unless validation_result[:success]
-        puts "Trust chain validation error message: #{validation_result[:error_message]}"
+        puts "Trust chain validation error message: #{validation_result[:error_message]}" # rubocop:disable RSpec/Output
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe UDAPSecurityTestKit::UDAPJWTValidator do # rubocop:disable RSpec/
 
       expect(validation_result[:success]).to be true
       unless validation_result[:success]
-        puts "JWT Signature validation error message: #{validation_result[:error_message]}"
+        puts "JWT Signature validation error message: #{validation_result[:error_message]}" # rubocop:disable RSpec/Output
       end
     end
   end

--- a/udap_security_test_kit.gemspec
+++ b/udap_security_test_kit.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'UDAP Security IG Test Kit'
   spec.homepage      = 'https://github.com/inferno-framework/udap-security-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_dependency 'inferno_core', '~> 1.0', '>= 1.0.2'
+  spec.add_dependency 'inferno_core', '~> 1.2', '>= 1.2.2'
   spec.add_dependency 'jwt', '~> 2.3'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.3.6')
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
# Summary
- Bumped inferno-core dependency to new released version to '~> 1.2', '>= 1.2.2'
- safe autocorrected rubocop offenses - disabled cops that weren't autocorrectable