### PR TITLE
Bumping jwt to 3.2 and addressing breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     udap_security_test_kit (0.12.0)
       inferno_core (~> 1.2, >= 1.2.2)
-      jwt (~> 2.3)
+      jwt (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -23,7 +23,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
-    auth-sanitizer (0.1.2)
+    auth-sanitizer (0.1.4)
       version_gem (~> 1.1, >= 1.1.9)
     base62-rb (0.3.1)
     base64 (0.3.0)
@@ -191,7 +191,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.5)
-    jwt (2.10.2)
+    jwt (3.2.0)
       base64
     kramdown (2.5.2)
       rexml (>= 3.4.4)
@@ -233,14 +233,14 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    oauth2 (2.0.19)
-      auth-sanitizer (~> 0.1)
+    oauth2 (2.0.20)
+      auth-sanitizer (~> 0.1, >= 0.1.3)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
+      snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
     oj (3.11.0)
     parallel (2.1.0)
@@ -366,7 +366,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux
@@ -396,7 +396,7 @@ CHECKSUMS
   activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  auth-sanitizer (0.1.2) sha256=29f7638d74b2a19ff890008f1561165668a78969a4d90bc85e991128825a7c03
+  auth-sanitizer (0.1.4) sha256=ded72221d4d3a7c91e34e8a87b21e6a42cbf7829697f140dcf49d542422faedc
   base62-rb (0.3.1) sha256=24e084c7e4101366ced80facf46913e4fe975b18409c55772747f44d18bf6aa0
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcp47 (0.3.3) sha256=e203e81a8f94425a0cbd3b2f05f466e5b321f38697412ba9cd121e02382d0825
@@ -456,7 +456,7 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
-  jwt (2.10.2) sha256=31e1ee46f7359883d5e622446969fe9c118c3da87a0b1dca765ce269c3a0c4f4
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
@@ -481,7 +481,7 @@ CHECKSUMS
   nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
   nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
   nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
-  oauth2 (2.0.19) sha256=175e12c18c3e786bd5c0f30a3235d17594ea36935d17aac5c1296497c0a42613
+  oauth2 (2.0.20) sha256=790c6316346da12f9dcaf27a67530f802950af05d35c3874918da84f2deae674
   oj (3.11.0) sha256=470d6ac425efd19c526ecea1cabb0219dd8bbcbdeeec57bd45a803b5e082ab5b
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
@@ -542,7 +542,7 @@ CHECKSUMS
   unicode_utils (1.4.0) sha256=b922d0cf2313b6b7136ada6645ce7154ffc86418ca07d53b058efe9eb72f2a40
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
-  zeitwerk (2.8.0) sha256=474d0a1d2429f635af7c4574f5ddbce0d0cfc286067c7515858b93a26b4f3e3d
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
    2.5.3

--- a/lib/udap_security_test_kit/client_suite/token_request_verification.rb
+++ b/lib/udap_security_test_kit/client_suite/token_request_verification.rb
@@ -94,7 +94,8 @@ module UDAPSecurityTestKit
       return unless decoded_token.present?
 
       # header checked with signature
-      check_jwt_payload(oauth_flow, decoded_token.payload, request_num, jti_list, registered_client_id, request_time)
+      check_jwt_payload(oauth_flow, decoded_token.unverified_payload, request_num, jti_list, registered_client_id,
+                        request_time)
       check_jwt_signature(decoded_token, registration_token, request_num)
     end
 

--- a/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
+++ b/spec/udap_security_test_kit/client_suite/mock_udap_server_spec.rb
@@ -66,10 +66,15 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
   end
   let(:udap_assertion_correct_cert) { make_signed_udap_jwt(udap_payload_invalid, leaf_key, [leaf_cert]) }
   let(:udap_assertion_wrong_cert) { make_signed_udap_jwt(udap_payload_invalid, root_key, [root_cert]) }
+  let(:udap_assertion_sig_invalid) do
+    parts = udap_assertion_correct_cert.split('.')
+    parts[2] = Base64.urlsafe_encode64(SecureRandom.bytes(256), padding: false)
+    parts.join('.')
+  end
   let(:udap_token_request_body_sig_invalid) do
     { grant_type: 'client_credentials',
       client_assertion_type: 'invalid',
-      client_assertion: "#{udap_assertion_correct_cert}bad",
+      client_assertion: udap_assertion_sig_invalid,
       udap: 1 }
   end
   let(:udap_token_request_body_sig_valid) do
@@ -103,7 +108,7 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
   let(:udap_ac_token_request_body_sig_invalid) do
     { grant_type: 'authorization_code',
       client_assertion_type: 'invalid',
-      client_assertion: "#{udap_assertion_correct_cert}bad",
+      client_assertion: udap_assertion_sig_invalid,
       udap: 1,
       code: authorization_code }
   end
@@ -119,7 +124,7 @@ RSpec.describe UDAPSecurityTestKit::MockUDAPServer, :request, :runnable do # rub
     { grant_type: 'refresh_token',
       refresh_token:,
       client_assertion_type: 'invalid',
-      client_assertion: "#{udap_assertion_correct_cert}bad",
+      client_assertion: udap_assertion_sig_invalid,
       udap: 1 }
   end
 

--- a/udap_security_test_kit.gemspec
+++ b/udap_security_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno-framework/udap-security-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_dependency 'inferno_core', '~> 1.2', '>= 1.2.2'
-  spec.add_dependency 'jwt', '~> 2.3'
+  spec.add_dependency 'jwt', '~> 3.2'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.3.6')
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/inferno-framework/udap-security-test-kit'


### PR DESCRIPTION
# Summary
JWT 3.x is more strict with signature segment validation before payload access. To address we:
- changed the '.payload' to '.unverified_payload' to bypass verification in **token_request_verification.rb**
- Replaced the "#{jwt}bad" pattern for all three sig_invalid let statements with a shared udap_assertion_sig_invalid let that splits the JWT and substitutes a valid-base64 random byte sequence as the signature segment in **mock_udap_server_spec.rb**. Appending "bad" corrupted the base64 encoding of the third segment, causing jwt 3.x to raise a decode error before ever reaching signature verification. 

